### PR TITLE
 $window.localMediaStream.stop(); not available on Chrome

### DIFF
--- a/qr-scanner.js
+++ b/qr-scanner.js
@@ -72,7 +72,7 @@ angular.module('qrScanner', ["ng"]).directive('qrScanner', ['$interval', '$windo
 
       element.bind('$destroy', function() {
         if ($window.localMediaStream) {
-          $window.localMediaStream.stop();
+          $window.localMediaStream.getTracks()[0].stop();
         }
         if (stopScan) {
           $interval.cancel(stopScan);


### PR DESCRIPTION
This don't work anymore in Google Chrome
https://developers.google.com/web/updates/2015/07/mediastream-deprecations?hl=en#stop-ended-and-active
$window.localMediaStream.stop();
and needs to be replaced by this : (which works one Firefox & Chrome)
$window.localMediaStream.getTracks()[0].stop();